### PR TITLE
Added check for stopped session hosts

### DIFF
--- a/StopSH-MultiHostPools.ps1
+++ b/StopSH-MultiHostPools.ps1
@@ -70,7 +70,7 @@ while ($count -lt $allHostPools.Count) {
     # Get the Session Hosts
     # Exclude servers in drain mode and do not allow new connections
     $runningSessionHosts = (Get-AzWvdSessionHost -HostPoolName $Pool -ResourceGroupName $PoolRg | Where-Object { $_.AllowNewSession -eq $true } )
-    $availableSessionHosts = ($runningSessionHosts | Where-Object { $_.Status -eq "Available" })
+    $availableSessionHosts = ($runningSessionHosts | Where-Object { $_.Status -eq "Available" -or "Stopped" })
     #Evaluate the list of running session hosts against 
     foreach ($sessionHost in $availableSessionHosts) {
         $sessionHostName = (($sessionHost).name -split { $_ -eq '.' -or $_ -eq '/' })[1]


### PR DESCRIPTION
Thank you for this script! It helped me out a ton! The one problem is that we don't restrict shut down access. If a user shuts down their AVD session host, the VM will stay stopped, but still allocated. We wanted to reduce our costs so I added a check if the status is Stopped. If the session host is stopped, it now gets deallocated.